### PR TITLE
Default topbar breakpoints updated to fit with the Foundation media queries

### DIFF
--- a/global/foundation/v5/scss/_vars.scss
+++ b/global/foundation/v5/scss/_vars.scss
@@ -25,7 +25,8 @@ $line-height: 1.25em;
 // Top Bar
 $topbar-height: 45px;
 $topbar-margin-bottom: 0;
-$topbar-breakpoint: $medium-up;
+$topbar-breakpoint: #{lower-bound($medium-range)};
+$topbar-media-query: $medium-up;
 $topbar-bg: transparent;
 $topbar-link-color: #000;
 $topbar-link-font-size: 0.9em;


### PR DESCRIPTION
Last pull for now, after this I should be satisfied
