### PR TITLE
Updated formy style for checkboxes and radio buttons

### DIFF
--- a/global/foundation/scss/_formy.scss
+++ b/global/foundation/scss/_formy.scss
@@ -13,7 +13,7 @@
     // Errors
     .error {
         p {
-            margin-top: 4px;
+            margin: 4px auto 10px;
             font-size: .8em;
             color: #c60f13;
         }
@@ -22,12 +22,10 @@
             background-color: rgba(198,15,19,0.1);
             margin-bottom: 0;
         }
-    }
-    fieldset div.error .checkbox, fieldset div.error .radio {
-        padding-bottom: 0px;
-    }
-    fieldset div.error .checkbox p, fieldset div.error .radio p {
-        padding-bottom: 15px;
+        .checkbox, .radio {
+            background-color: rgba(198,15,19,0.1);
+            padding-bottom: 0;
+        }
     }
 
     // Labels
@@ -37,24 +35,27 @@
     }
 
     // Checkboxes and radio
-    fieldset div.checkbox input, fieldset div.radio input {
+    div.checkbox input, div.radio input {
         margin: 0px;
         padding: 0px;
     }
-    fieldset div.checkbox, fieldset div.radio {
+    div.checkbox, div.radio {
         margin: 0px;
-        padding: 0px 0px 20px 0px;
+        padding: 0px 0px 15px 0px;
         border: 0px;
         float: none;
     }
-    fieldset div.checkbox div, fieldset div.radio div {
+    div.checkbox div, div.radio div {
         border: 0px;
         margin: 4px 0px 0px 0px;
     }
-    fieldset div.checkbox label, fieldset div.radio label {
+    div.checkbox label, div.radio label {
         float: none;
         display: inline;
         margin-left: 5px;
+    }
+    div.checkbox input[type=checkbox], div.radio input[type=radio] {
+        margin-bottom: 0;
     }
 
     // The subit button

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "styleguide",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "description": "Wayne State University Style Guide",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Noticed a spacing issue (overspacing) on radio buttons and decided to investigate further. What I found was a few inconsistencies in the styleguide for formy forms and the HTML output.

**Before:**
![screen shot 2015-09-02 at 2 26 11 pm](https://cloud.githubusercontent.com/assets/37359/9640950/2264961e-5182-11e5-9998-75801c8231e9.png)
*Way too much space in between radio buttons (same was true for checkboxes)*

Discovered there was code in the styleguide to correct this but it was scoped within a `fieldset`, with a change to Formy recently the entire form is no longer wrapped in a `fieldset` and there is also no longer a `legend` for the form.

**Examples before**
![screen shot 2015-09-02 at 2 29 58 pm](https://cloud.githubusercontent.com/assets/37359/9641022/79a4a4e6-5182-11e5-9c50-cf957f8e978b.png) 
![screen shot 2015-09-02 at 2 54 38 pm](https://cloud.githubusercontent.com/assets/37359/9641037/8d374414-5182-11e5-9426-d2f98e90364c.png)

**Examples after using code from this PR**
![screen shot 2015-09-02 at 2 29 48 pm](https://cloud.githubusercontent.com/assets/37359/9641053/a821916c-5182-11e5-9e0f-e8734fc72099.png) 
![screen shot 2015-09-02 at 2 55 54 pm](https://cloud.githubusercontent.com/assets/37359/9641066/bcba02b2-5182-11e5-9da7-803d670a8ba7.png)

**A few small tweaks to the `.error` state were also needed, here is the result:**
![screen shot 2015-09-02 at 2 43 13 pm](https://cloud.githubusercontent.com/assets/37359/9641086/cefba43a-5182-11e5-8cd9-ddc888448027.png)

cc/ @robertvrabel @chrispelzer @tomkrupka @breakdancingcat 