### PR TITLE
Browsers will no longer throw a console notice when on HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "styleguide",
-    "version": "0.2.9",
+    "version": "0.2.10",
     "description": "Wayne State University Style Guide",
     "repository": {
         "type": "git",

--- a/wsuheader/foundation/header.tpl
+++ b/wsuheader/foundation/header.tpl
@@ -16,7 +16,7 @@
                 </ul>
             </nav>
 
-            <form method="get" action="http://wayne.edu/search/">
+            <form method="get" action="https://wayne.edu/search/">
                 <div class="row collapse">
                     <div class="small-10 medium-10 columns">
                         <label for="q">Search:</label>


### PR DESCRIPTION
**Problem:**

When visiting a website in `https://` chrome will throw a console notice that there are insecure forms on the page. 

**Example: [https://comm.wayne.edu/](https://comm.wayne.edu/)**

![screen shot 2015-09-25 at 6 32 15 am](https://cloud.githubusercontent.com/assets/37359/10098737/949f4644-6351-11e5-9277-4fa80e7e437a.png)

**Proposal**

The form throwing the notice is the search bar at the top. Since it is available in `https://` this change forces all search traffic through the secure version of the page. This results in no user visible change other than the reduced warning if on an `https://` site.

cc/ @robertvrabel @chrispelzer @tomkrupka @breakdancingcat 