### PR TITLE
Add underline style to links in a label

### DIFF
--- a/global/foundation/scss/_formy.scss
+++ b/global/foundation/scss/_formy.scss
@@ -32,6 +32,10 @@
     label {
         color: #4d4d4d;
         font-size: 1em;
+
+        a {
+            text-decoration: underline;
+        }
     }
 
     // Checkboxes and radio

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waynestate/styleguide",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "description": "Wayne State University Style Guide",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Right now it isn't very user-friendly if someone adds a link in the formy label field. This adds some indicator that you can click the text.

![screen shot 2016-03-15 at 2 01 05 pm](https://cloud.githubusercontent.com/assets/634788/13788526/703ccbea-eab6-11e5-9ba4-a1b216ee3479.png)
