### PR TITLE
Header height now more in line with hight from Foundation 5 header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@waynestate/styleguide",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Wayne State University Style Guide",
     "repository": {
         "type": "git",

--- a/src/scss/_wsuheader.scss
+++ b/src/scss/_wsuheader.scss
@@ -84,6 +84,11 @@
             }
         }
 
+        // To avoid double spacing below the input box since it is already on the container
+        .input-group {
+            margin-bottom: 0;
+        }
+
         // This is to make the background color of the button white so it matches the height of the rest of the search box
         .input-group-button {
             background: #fff;


### PR DESCRIPTION
## Issue

In order to make a release for the generator we noticed the header was quite a bit higher than the Foundation 5 version:

![fd6-fd5](https://cloud.githubusercontent.com/assets/37359/15974513/d4a9a9be-2f16-11e6-8702-3a8cfd720baf.png)

This was due to a padding difference in form elements and the header already having padding on it. 

## Solution

Remove the padding on the form `input` element in the header and allow the parent element padding to take over.

## Result

![header](https://cloud.githubusercontent.com/assets/37359/15974624/6f02ecaa-2f17-11e6-8c6f-afe254a4708c.gif)

A header that is slightly larger (3px) than the current header. To get it exact would mean to overwrite the padding on the input element itself on the header only. After messing around with it a little bit I feel that having this one form element different than all other form elements on the page (because all new sites will inherit the Foundation 6 style from this styleguide) would make it feel weird.

So this yeilds to the Foundation 6 native sizes/padding for as much as possible.